### PR TITLE
Adding handling for non-DDBPROXY implementation

### DIFF
--- a/.github/workflows/deploy-aas.yml
+++ b/.github/workflows/deploy-aas.yml
@@ -19,8 +19,9 @@ on:
         required: true
         type: string
       DEPLOY_DDBPROXY:
-        required: true
+        required: false
         type: string
+        default: false
       DEPLOY_BASTION:
         required: false
         type: string

--- a/.github/workflows/deploy-foundryvtt.yml
+++ b/.github/workflows/deploy-foundryvtt.yml
@@ -6,7 +6,7 @@ on:
       - main
   workflow_dispatch:
   schedule:
-    #- cron: '0 14 * * *' # 2am NZT (UTC+12)
+    - cron: '0 14 * * *' # 2am NZT (UTC+12)
     
 permissions:
   id-token: write

--- a/.github/workflows/deploy-foundryvtt.yml
+++ b/.github/workflows/deploy-foundryvtt.yml
@@ -6,7 +6,7 @@ on:
       - main
   workflow_dispatch:
   schedule:
-    - cron: '0 14 * * *' # 2am NZT (UTC+12)
+    #- cron: '0 14 * * *' # 2am NZT (UTC+12)
     
 permissions:
   id-token: write

--- a/bicep/appService.bicep
+++ b/bicep/appService.bicep
@@ -134,6 +134,4 @@ module bastion './modules/bastion.bicep' = if (deployBastion) {
 }
 
 output url string = webAppFoundryVtt.outputs.url
-if (deployDdbProxy) {
-  output ddbproxyurl string = webAppDdbProxy.outputs.url
-}
+output ddbproxyurl string = webAppDdbProxy.outputs.url ?? ''

--- a/bicep/appService.bicep
+++ b/bicep/appService.bicep
@@ -134,4 +134,6 @@ module bastion './modules/bastion.bicep' = if (deployBastion) {
 }
 
 output url string = webAppFoundryVtt.outputs.url
-output ddbproxyurl string = webAppDdbProxy.outputs.url
+if (deployDdbProxy) {
+  output ddbproxyurl string = webAppDdbProxy.outputs.url
+}

--- a/bicep/appService.bicep
+++ b/bicep/appService.bicep
@@ -134,4 +134,4 @@ module bastion './modules/bastion.bicep' = if (deployBastion) {
 }
 
 output url string = webAppFoundryVtt.outputs.url
-output ddbproxyurl string = webAppDdbProxy.outputs.url ?? ''
+output ddbproxyurl string = deployDdbProxy ? webAppDdbProxy.outputs.url : ''


### PR DESCRIPTION
I'm deploying this to play Pathfinder so I did not need the DDBPROXY installed. I noticed that it was failing to deploy without the DEPLOY_DDBPROXY value, and once a value of false was added the deployment was still failing. This failure was due to the output for the ddbproxyurl string in the appService.bicep file referencing a null value; it has been updated to return an empty string if it is null. I also updated the deploy-aas.yml file to make DEPLOY_DDBPROXY optional and false by default.