### PR TITLE
Adding handling for non-DDBPROXY implementation

### DIFF
--- a/.github/workflows/deploy-aas.yml
+++ b/.github/workflows/deploy-aas.yml
@@ -19,8 +19,9 @@ on:
         required: true
         type: string
       DEPLOY_DDBPROXY:
-        required: true
+        required: false
         type: string
+        default: 'false'
       DEPLOY_BASTION:
         required: false
         type: string

--- a/bicep/appService.bicep
+++ b/bicep/appService.bicep
@@ -134,4 +134,4 @@ module bastion './modules/bastion.bicep' = if (deployBastion) {
 }
 
 output url string = webAppFoundryVtt.outputs.url
-output ddbproxyurl string = webAppDdbProxy.outputs.url
+output ddbproxyurl string = deployDdbProxy ? webAppDdbProxy.outputs.url : ''


### PR DESCRIPTION
I'm deploying this to play Pathfinder so I did not need the DDBPROXY installed. I noticed that it was failing to deploy without the DEPLOY_DDBPROXY value, and once a value of false was added, the deployment was still failing. This failure was due to the output for the ddbproxyurl string in the appService.bicep file referencing a null value; it has been updated to return an empty string if it is null. 
I also updated the deploy-aas.yml file to make DEPLOY_DDBPROXY optional and false by default.
